### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,76 @@
 
 All notable changes to this project will be documented in this file.
 
+## terminput-termwiz - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-termion - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-egui - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-crossterm - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput - [0.4.0](https://github.com/aschey/terminput/compare/0.3.1..0.4.0) - 2025-03-25
+
+### Refactor
+
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
 ## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14
 
 ### Dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,67 +3,26 @@
 All notable changes to this project will be documented in this file.
 
 ## terminput-termwiz - [0.1.0] - 2025-03-25
-
-### Documentation
-
-- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
-- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
-
-### Features
-
-- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
-
 ### Refactor
 
-- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
 - [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
 
 ## terminput-termion - [0.1.0] - 2025-03-25
 
-### Documentation
-
-- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
-- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
-
-### Features
-
-- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
-
 ### Refactor
 
-- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
 - [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
 
 ## terminput-egui - [0.1.0] - 2025-03-25
 
-### Documentation
-
-- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
-- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
-
-### Features
-
-- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
-
 ### Refactor
 
-- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
 - [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
 
 ## terminput-crossterm - [0.1.0] - 2025-03-25
 
-### Documentation
-
-- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
-- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
-
-### Features
-
-- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
-
 ### Refactor
 
-- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
 - [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
 
 ## terminput - [0.4.0](https://github.com/aschey/terminput/compare/0.3.1..0.4.0) - 2025-03-25

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -18,7 +18,7 @@ crossterm = { version = "0.28", default-features = false, features = [
   "events",
   "bracketed-paste",
 ] }
-terminput = { path = "../terminput", version = "0.3.1" }
+terminput = { path = "../terminput", version = "0.4.0" }
 
 [lints]
 workspace = true

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
-terminput = { path = "../terminput", version = "0.3.1" }
+terminput = { path = "../terminput", version = "0.4.0" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 
 [dependencies]
 termion = { version = "4" }
-terminput = { path = "../terminput" }
+terminput = { path = "../terminput", version = "0.4.0" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -15,7 +15,7 @@ keywords.workspace = true
 
 [dependencies]
 termwiz = { version = "0.22" }
-terminput = { path = "../terminput", version = "0.3.1" }
+terminput = { path = "../terminput", version = "0.4.0" }
 
 [lints]
 workspace = true

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.3.1"
+version = "0.4.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.3.1 -> 0.4.0 (⚠ API breaking changes)
* `terminput-crossterm`: 0.1.0
* `terminput-egui`: 0.1.0
* `terminput-termion`: 0.1.0
* `terminput-termwiz`: 0.1.0

### ⚠ `terminput` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.40.0/src/lints/feature_missing.ron

Failed in:
  feature termion in the package's Cargo.toml
  feature termwiz in the package's Cargo.toml
  feature egui in the package's Cargo.toml
  feature crossterm in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-egui`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).