### PR TITLE
chore: release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,86 @@
 All notable changes to this project will be documented in this file.
 
 ## terminput-termwiz - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Miscellaneous Tasks
+
+- Release ([#18](https://github.com/aschey/terminput/issues/18)) - ([7ab613b](https://github.com/aschey/terminput/commit/7ab613b7db77b792a7252fd1a1ac3004d19de355))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-termion - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Miscellaneous Tasks
+
+- Release ([#18](https://github.com/aschey/terminput/issues/18)) - ([7ab613b](https://github.com/aschey/terminput/commit/7ab613b7db77b792a7252fd1a1ac3004d19de355))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-egui - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Miscellaneous Tasks
+
+- Release ([#18](https://github.com/aschey/terminput/issues/18)) - ([7ab613b](https://github.com/aschey/terminput/commit/7ab613b7db77b792a7252fd1a1ac3004d19de355))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-crossterm - [0.1.0] - 2025-03-25
+
+### Documentation
+
+- Add docs.rs metadata config ([#2](https://github.com/aschey/terminput/issues/2)) - ([f1f0e95](https://github.com/aschey/terminput/commit/f1f0e957540eedc2fdab8d2ff7011497187dc540))
+- Fix link typo ([#6](https://github.com/aschey/terminput/issues/6)) - ([f49e6f1](https://github.com/aschey/terminput/commit/f49e6f1904cabe52c4124e4d1b2821f40ba0dd80))
+
+### Features
+
+- Add helpers for event matching ([#13](https://github.com/aschey/terminput/issues/13)) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))
+
+### Miscellaneous Tasks
+
+- Release ([#18](https://github.com/aschey/terminput/issues/18)) - ([7ab613b](https://github.com/aschey/terminput/commit/7ab613b7db77b792a7252fd1a1ac3004d19de355))
+
+### Refactor
+
+- [**breaking**] Rename parse_event to Event::parse_from ([#4](https://github.com/aschey/terminput/issues/4)) - ([e02d9ab](https://github.com/aschey/terminput/commit/e02d9ab77aa82c487676ee5e76e65bd7c7cbd469))
+- [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))
+
+## terminput-termwiz - [0.1.0] - 2025-03-25
 ### Refactor
 
 - [**breaking**] Break adapters into separate crates ([#17](https://github.com/aschey/terminput/issues/17)) - ([78d098c](https://github.com/aschey/terminput/commit/78d098cf9629a53cab25cd16a488351e95497f69))


### PR DESCRIPTION



## 🤖 New release

* `terminput-crossterm`: 0.1.0
* `terminput-egui`: 0.1.0
* `terminput-termion`: 0.1.0
* `terminput-termwiz`: 0.1.0

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput-crossterm`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-egui`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).