### PR TITLE
chore: release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,36 @@
 
 All notable changes to this project will be documented in this file.
 
+## terminput-termwiz - [0.2.1] - 2025-03-25
+
+### Documentation
+
+- Use correct readme paths ([#25](https://github.com/aschey/terminput/issues/25)) - ([ac93b8a](https://github.com/aschey/terminput/commit/ac93b8ac5611af6642cee47be58ec528412a3653))
+
+## terminput-termion - [0.1.1] - 2025-03-25
+
+### Documentation
+
+- Use correct readme paths ([#25](https://github.com/aschey/terminput/issues/25)) - ([ac93b8a](https://github.com/aschey/terminput/commit/ac93b8ac5611af6642cee47be58ec528412a3653))
+
+## terminput-egui - [0.1.1] - 2025-03-25
+
+### Documentation
+
+- Use correct readme paths ([#25](https://github.com/aschey/terminput/issues/25)) - ([ac93b8a](https://github.com/aschey/terminput/commit/ac93b8ac5611af6642cee47be58ec528412a3653))
+
+## terminput-crossterm - [0.1.1] - 2025-03-25
+
+### Documentation
+
+- Use correct readme paths ([#25](https://github.com/aschey/terminput/issues/25)) - ([ac93b8a](https://github.com/aschey/terminput/commit/ac93b8ac5611af6642cee47be58ec528412a3653))
+
+## terminput - [0.4.1] - 2025-03-25
+
+### Documentation
+
+- Use correct readme paths ([#25](https://github.com/aschey/terminput/issues/25)) - ([ac93b8a](https://github.com/aschey/terminput/commit/ac93b8ac5611af6642cee47be58ec528412a3653))
+
 ## terminput-termwiz - [0.2.0] - 2025-03-25
 
 ### Dependencies

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -18,7 +18,7 @@ crossterm = { version = "0.28", default-features = false, features = [
   "events",
   "bracketed-paste",
 ] }
-terminput = { path = "../terminput", version = "0.4.0" }
+terminput = { path = "../terminput", version = "0.4.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
-terminput = { path = "../terminput", version = "0.4.0" }
+terminput = { path = "../terminput", version = "0.4.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.1.0"
+version = "0.1.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 termion = { version = "4" }
-terminput = { path = "../terminput", version = "0.4.0" }
+terminput = { path = "../terminput", version = "0.4.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "../README.md"
 
 [dependencies]
 termwiz = { version = "0.23" }
-terminput = { path = "../terminput", version = "0.4.0" }
+terminput = { path = "../terminput", version = "0.4.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `terminput-crossterm`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `terminput-egui`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `terminput-termion`: 0.1.0 -> 0.1.1 (✓ API compatible changes)
* `terminput-termwiz`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-egui`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).