### PR TITLE
chore: release v0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## terminput-termion - [0.1.2] - 2025-03-25
+
+### Bug Fixes
+
+- Windows build issues ([#28](https://github.com/aschey/terminput/issues/28)) - ([2e571f2](https://github.com/aschey/terminput/commit/2e571f28e0409efb4d6a1d7ba2cc05cd7e8ec79e))
+
+## terminput-crossterm - [0.1.2] - 2025-03-25
+
+### Bug Fixes
+
+- Windows build issues ([#28](https://github.com/aschey/terminput/issues/28)) - ([2e571f2](https://github.com/aschey/terminput/commit/2e571f28e0409efb4d6a1d7ba2cc05cd7e8ec79e))
+
 ## terminput-termwiz - [0.2.1] - 2025-03-25
 
 ### Documentation

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput-crossterm`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `terminput-termion`: 0.1.1 -> 0.1.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput-crossterm`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/0.3.0..0.3.1) - 2025-02-14

### Dependencies

- *(deps)* Support termwiz 0.22-0.23 (#14) - ([71fe322](https://github.com/aschey/terminput/commit/71fe322093553d38daa1e94da1199320454d6bd8))

### Features

- Add helpers for event matching (#13) - ([b95512e](https://github.com/aschey/terminput/commit/b95512ebae0fb5fb0234a8120bf8031e52bcedc8))

<!-- generated by git-cliff -->
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).