### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.1.2..terminput-crossterm-v0.1.3) - 2025-04-05
+
+### Dependencies
+
+- *(deps)* Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))
+
+### Documentation
+
+- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
+
 ## [0.1.2](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.1.1..terminput-crossterm-v0.1.2) - 2025-03-25
 
 ### Bug Fixes

--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,11 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
-## [0.1.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.1.2..terminput-crossterm-v0.1.3) - 2025-04-05
+## [0.2.0](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.1.2..terminput-crossterm-v0.2.0) - 2025-04-05
 
 ### Dependencies
 
-- *(deps)* Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))
+- *(deps)* [**breaking**] Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))
 
 ### Documentation
 

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ crossterm = { version = "0.29", default-features = false, features = [
   "bracketed-paste",
   "windows",
 ] }
-terminput = { path = "../terminput", version = "0.4.1" }
+terminput = { path = "../terminput", version = "0.4.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.1.3"
+version = "0.2.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.1.1..terminput-egui-v0.1.2) - 2025-04-05
+
+### Documentation
+
+- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
+
 ## [0.1.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.1.0..terminput-egui-v0.1.1) - 2025-03-25
 
 ### Documentation

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
-terminput = { path = "../terminput", version = "0.4.1" }
+terminput = { path = "../terminput", version = "0.4.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.1.2..terminput-termion-v0.1.3) - 2025-04-05
+
+### Documentation
+
+- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
+
 ## [0.1.2](https://github.com/aschey/terminput/compare/terminput-termion-v0.1.1..terminput-termion-v0.1.2) - 2025-03-25
 
 ### Bug Fixes

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion = { version = "4" }
-terminput = { path = "../terminput", version = "0.4.1" }
+terminput = { path = "../terminput", version = "0.4.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.2](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.2.1..terminput-termwiz-v0.2.2) - 2025-04-05
+
+### Documentation
+
+- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
+
 ## [0.2.1](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.2.0..terminput-crossterm-v0.2.1) - 2025-03-25
 
 ### Documentation

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termwiz = { version = "0.23" }
-terminput = { path = "../terminput", version = "0.4.1" }
+terminput = { path = "../terminput", version = "0.4.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3](https://github.com/aschey/terminput/compare/terminput-v0.4.2..terminput-v0.4.3) - 2025-04-05
+
+### Dependencies
+
+- *(deps)* Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))
+
 ## [0.4.2](https://github.com/aschey/terminput/compare/terminput-v0.4.1..terminput-v0.4.2) - 2025-03-25
 
 ### Documentation

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION


## 🤖 New release

* `terminput`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `terminput-crossterm`: 0.1.2 -> 0.2.0 (✓ API compatible changes)
* `terminput-egui`: 0.1.1 -> 0.1.2 (✓ API compatible changes)
* `terminput-termion`: 0.1.2 -> 0.1.3 (✓ API compatible changes)
* `terminput-termwiz`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.4.3](https://github.com/aschey/terminput/compare/terminput-v0.4.2..terminput-v0.4.3) - 2025-04-05

### Dependencies

- *(deps)* Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.2.0](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.1.2..terminput-crossterm-v0.2.0) - 2025-04-05

### Dependencies

- *(deps)* [**breaking**] Update crossterm requirement from 0.28 to 0.29 ([#34](https://github.com/aschey/terminput/issues/34)) - ([db9c309](https://github.com/aschey/terminput/commit/db9c309b65c262d4bbe9e5f587344b85a01a3be6))

### Documentation

- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.1.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.1.1..terminput-egui-v0.1.2) - 2025-04-05

### Documentation

- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.1.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.1.2..terminput-termion-v0.1.3) - 2025-04-05

### Documentation

- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.2.2](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.2.1..terminput-termwiz-v0.2.2) - 2025-04-05

### Documentation

- Add missing doc_auto_cfg ([#36](https://github.com/aschey/terminput/issues/36)) - ([04d6748](https://github.com/aschey/terminput/commit/04d67484b85b73e58b16e9c8ebbb40b53b2a17c3))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).