### PR TITLE
terminput: add support for `no_std`

### DIFF
--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -22,7 +22,9 @@ crossterm = "0.29"
 terminput-crossterm = { path = "../terminput-crossterm" }
 
 [features]
+default = ["std"]
 serde = ["dep:serde", "bitflags/serde"]
+std = []
 
 [lints]
 workspace = true

--- a/crates/terminput/src/encoder.rs
+++ b/crates/terminput/src/encoder.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
+use std::format;
 use std::io::{self, Cursor, Seek, Write};
+use std::string::{String, ToString};
 
 use bitflags::bitflags;
 

--- a/crates/terminput/src/key.rs
+++ b/crates/terminput/src/key.rs
@@ -1,4 +1,4 @@
-use std::hash::{Hash, Hasher};
+use core::hash::{Hash, Hasher};
 
 use bitflags::bitflags;
 

--- a/crates/terminput/src/lib.rs
+++ b/crates/terminput/src/lib.rs
@@ -1,15 +1,24 @@
+#![no_std]
 #![deny(missing_docs)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 
+extern crate alloc;
+#[cfg(feature = "std")]
+extern crate std;
+
+#[cfg(feature = "std")]
 mod encoder;
 mod key;
 mod mouse;
+#[cfg(feature = "std")]
 mod parser;
 
+use alloc::string::String;
+use core::error::Error;
 use core::fmt;
-use std::error::Error;
 
+#[cfg(feature = "std")]
 pub use encoder::*;
 pub use key::*;
 pub use mouse::*;

--- a/crates/terminput/src/parser/mod.rs
+++ b/crates/terminput/src/parser/mod.rs
@@ -2,6 +2,7 @@
 // https://github.com/crossterm-rs/crossterm/blob/master/src/event/sys/unix/parse.rs
 
 use std::io;
+use std::string::{String, ToString};
 
 use crate::{
     Event, KeyCode, KeyEvent, KeyEventKind, KeyEventState, KeyModifiers, MediaKeyCode,


### PR DESCRIPTION
This adds support for `no_std` to `terminput`.

This is an opt-in feature (defaults continue to be `std`). This is intended to be used with ratatui on uefi (https://github.com/reubeno/tui-uefi) with stable builds.