### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.0..terminput-crossterm-v0.3.1) - 2025-07-01
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.0](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.2.1..terminput-crossterm-v0.3.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ crossterm = { version = "0.29", default-features = false, features = [
   "bracketed-paste",
   "windows",
 ] }
-terminput = { path = "../terminput", version = "0.5.0" }
+terminput = { path = "../terminput", version = "0.5.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.2.0..terminput-egui-v0.2.1) - 2025-07-01
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.2.0](https://github.com/aschey/terminput/compare/terminput-egui-v0.1.3..terminput-egui-v0.2.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui = { version = "0.31", default-features = false }
-terminput = { path = "../terminput", version = "0.5.0" }
+terminput = { path = "../terminput", version = "0.5.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.0..terminput-termion-v0.2.1) - 2025-07-01
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.2.0](https://github.com/aschey/terminput/compare/terminput-termion-v0.1.4..terminput-termion-v0.2.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion = { version = "4" }
-terminput = { path = "../terminput", version = "0.5.0" }
+terminput = { path = "../terminput", version = "0.5.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.0..terminput-termwiz-v0.3.1) - 2025-07-01
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.0](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.2.3..terminput-termwiz-v0.3.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termwiz = { version = "0.23" }
-terminput = { path = "../terminput", version = "0.5.0" }
+terminput = { path = "../terminput", version = "0.5.1" }
 
 [lints]
 workspace = true

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1](https://github.com/aschey/terminput/compare/terminput-v0.5.0..terminput-v0.5.1) - 2025-07-01
+
+### Documentation
+
+- Document feature flags ([#43](https://github.com/aschey/terminput/issues/43)) - ([a12a415](https://github.com/aschey/terminput/commit/a12a415f78156f400d197de68e8d6698348b5479))
+
+### Terminput
+
+- Add support for `no_std` ([#41](https://github.com/aschey/terminput/issues/41)) - ([f309625](https://github.com/aschey/terminput/commit/f3096259526ceee8a42b4c5814b77e23725cf9a9))
+
 ## [0.5.0](https://github.com/aschey/terminput/compare/terminput-v0.4.3..terminput-v0.5.0) - 2025-05-16
 
 ### Miscellaneous Tasks

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.0"
+version = "0.5.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.5.0 -> 0.5.1 (✓ API compatible changes)
* `terminput-crossterm`: 0.3.0 -> 0.3.1
* `terminput-egui`: 0.2.0 -> 0.2.1
* `terminput-termion`: 0.2.0 -> 0.2.1
* `terminput-termwiz`: 0.3.0 -> 0.3.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.1](https://github.com/aschey/terminput/compare/terminput-v0.5.0..terminput-v0.5.1) - 2025-07-01

### Documentation

- Document feature flags ([#43](https://github.com/aschey/terminput/issues/43)) - ([a12a415](https://github.com/aschey/terminput/commit/a12a415f78156f400d197de68e8d6698348b5479))

### Terminput

- Add support for `no_std` ([#41](https://github.com/aschey/terminput/issues/41)) - ([f309625](https://github.com/aschey/terminput/commit/f3096259526ceee8a42b4c5814b77e23725cf9a9))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.0..terminput-crossterm-v0.3.1) - 2025-07-01

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.2.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.2.0..terminput-egui-v0.2.1) - 2025-07-01

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.2.1](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.0..terminput-termion-v0.2.1) - 2025-07-01

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.0..terminput-termwiz-v0.3.1) - 2025-07-01

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).