### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.2..terminput-crossterm-v0.3.3) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.2](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.1..terminput-crossterm-v0.3.2) - 2025-07-13
 
 ### Miscellaneous Tasks

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -19,7 +19,7 @@ crossterm = { version = "0.29", default-features = false, features = [
   "bracketed-paste",
   "windows",
 ] }
-terminput = { path = "../terminput", version = "0.5.2" }
+terminput = { path = "../terminput", version = "0.5.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.3.1..terminput-egui-v0.3.2) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.3.0..terminput-egui-v0.3.1) - 2025-07-13
 
 ### Miscellaneous Tasks

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.3.1"
+version = "0.3.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui = { version = "0.32", default-features = false }
-terminput = { path = "../terminput", version = "0.5.2" }
+terminput = { path = "../terminput", version = "0.5.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.2..terminput-termion-v0.2.3) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.2.2](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.1..terminput-termion-v0.2.2) - 2025-07-13
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion = { version = "4" }
-terminput = { path = "../terminput", version = "0.5.2" }
+terminput = { path = "../terminput", version = "0.5.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.2..terminput-termwiz-v0.3.3) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.2](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.1..terminput-termwiz-v0.3.2) - 2025-07-13
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termwiz = { version = "0.23" }
-terminput = { path = "../terminput", version = "0.5.2" }
+terminput = { path = "../terminput", version = "0.5.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput-web-sys/CHANGELOG.md
+++ b/crates/terminput-web-sys/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.1](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.1.0..terminput-web-sys-v0.1.1) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.1.0] - 2025-07-13
 
 ### Features

--- a/crates/terminput-web-sys/Cargo.toml
+++ b/crates/terminput-web-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-web-sys"
-version = "0.1.0"
+version = "0.1.1"
 description = "web-sys adapter for terminput"
 edition.workspace = true
 rust-version.workspace = true
@@ -25,7 +25,7 @@ web-sys = { version = "0.3.77", features = [
   "Window",
   "Element",
 ] }
-terminput = { path = "../terminput", version = "0.5.2" }
+terminput = { path = "../terminput", version = "0.5.3" }
 
 [lints]
 workspace = true

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.3](https://github.com/aschey/terminput/compare/terminput-v0.5.2..terminput-v0.5.3) - 2025-07-13
+
+### Miscellaneous Tasks
+
+- Fix readme typo ([#50](https://github.com/aschey/terminput/issues/50)) - ([ca6a995](https://github.com/aschey/terminput/commit/ca6a995821ec9b9461ba9d58d58574941f001e39))
+
 ## [0.5.2](https://github.com/aschey/terminput/compare/terminput-v0.5.1..terminput-v0.5.2) - 2025-07-13
 
 ### Features

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.2"
+version = "0.5.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.5.2 -> 0.5.3 (✓ API compatible changes)
* `terminput-crossterm`: 0.3.2 -> 0.3.3
* `terminput-egui`: 0.3.1 -> 0.3.2
* `terminput-termion`: 0.2.2 -> 0.2.3
* `terminput-termwiz`: 0.3.2 -> 0.3.3
* `terminput-web-sys`: 0.1.0 -> 0.1.1

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.3](https://github.com/aschey/terminput/compare/terminput-v0.5.2..terminput-v0.5.3) - 2025-07-13

### Miscellaneous Tasks

- Fix readme typo ([#50](https://github.com/aschey/terminput/issues/50)) - ([ca6a995](https://github.com/aschey/terminput/commit/ca6a995821ec9b9461ba9d58d58574941f001e39))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.3.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.2..terminput-crossterm-v0.3.3) - 2025-07-13

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.3.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.3.1..terminput-egui-v0.3.2) - 2025-07-13

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.2.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.2..terminput-termion-v0.2.3) - 2025-07-13

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.3.3](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.2..terminput-termwiz-v0.3.3) - 2025-07-13

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-web-sys`

<blockquote>

## [0.1.1](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.1.0..terminput-web-sys-v0.1.1) - 2025-07-13

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).