### PR TITLE
chore: allow unwrap in tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,6 @@ keywords = ["tui", "terminal", "input", "ratatui"]
 broken_intra_doc_links = "deny"
 
 [workspace.lints.clippy]
-unwrap_used = "deny"
 doc_markdown = "warn"
 default_trait_access = "warn"
 ignored_unit_patterns = "warn"

--- a/crates/terminput-crossterm/src/lib.rs
+++ b/crates/terminput-crossterm/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/crates/terminput-egui/src/lib.rs
+++ b/crates/terminput-egui/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/crates/terminput-termion/src/lib.rs
+++ b/crates/terminput-termion/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/crates/terminput-termwiz/src/lib.rs
+++ b/crates/terminput-termwiz/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/crates/terminput-web-sys/src/lib.rs
+++ b/crates/terminput-web-sys/src/lib.rs
@@ -1,4 +1,4 @@
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 

--- a/crates/terminput/src/lib.rs
+++ b/crates/terminput/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![deny(missing_docs)]
+#![deny(missing_docs, clippy::unwrap_used)]
 #![cfg_attr(docsrs, feature(doc_auto_cfg))]
 #![doc = include_str!("../README.md")]
 


### PR DESCRIPTION
Applying this at the crate level was causing false positives with rust analyzer.