### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.0..terminput-crossterm-v0.4.1) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.4.0](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.3.3..terminput-crossterm-v0.4.0) - 2025-08-15
 
 ### Features

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ default-features = false
 features = ["events", "bracketed-paste", "windows"]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.4" }
+terminput = { path = "../terminput", version = "0.5.5" }
 
 [features]
 crossterm_0_28 = ["dep:crossterm_0_28"]

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.0..terminput-egui-v0.4.1) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.4.0](https://github.com/aschey/terminput/compare/terminput-egui-v0.3.2..terminput-egui-v0.4.0) - 2025-08-15
 
 ### Features

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui_0_32 = { package = "egui", version = "0.32", default-features = false, optional = true }
-terminput = { path = "../terminput", version = "0.5.4" }
+terminput = { path = "../terminput", version = "0.5.5" }
 
 [features]
 egui_0_32 = ["dep:egui_0_32"]

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.1](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.0..terminput-termion-v0.3.1) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.3.0](https://github.com/aschey/terminput/compare/terminput-termion-v0.2.3..terminput-termion-v0.3.0) - 2025-08-15
 
 ### Features

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.3.0"
+version = "0.3.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion_4 = { package = "termion", version = "4", optional = true }
-terminput = { path = "../terminput", version = "0.5.4" }
+terminput = { path = "../terminput", version = "0.5.5" }
 
 [features]
 termion_4 = ["dep:termion_4"]

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.0..terminput-termwiz-v0.4.1) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.4.0](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.3.3..terminput-termwiz-v0.4.0) - 2025-08-15
 
 ### Features

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.4.0"
+version = "0.4.1"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ readme = "./README.md"
 [dependencies]
 termwiz_0_23 = { package = "termwiz", version = "0.23", optional = true }
 termwiz_0_22 = { package = "termwiz", version = "0.22", optional = true }
-terminput = { path = "../terminput", version = "0.5.4" }
+terminput = { path = "../terminput", version = "0.5.5" }
 
 [features]
 termwiz_0_23 = ["dep:termwiz_0_23"]

--- a/crates/terminput-web-sys/CHANGELOG.md
+++ b/crates/terminput-web-sys/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.1](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.0..terminput-web-sys-v0.2.1) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.2.0](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.1.2..terminput-web-sys-v0.2.0) - 2025-08-15
 
 ### Features

--- a/crates/terminput-web-sys/Cargo.toml
+++ b/crates/terminput-web-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-web-sys"
-version = "0.2.0"
+version = "0.2.1"
 description = "web-sys adapter for terminput"
 edition.workspace = true
 rust-version.workspace = true
@@ -30,7 +30,7 @@ features = [
 ]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.4" }
+terminput = { path = "../terminput", version = "0.5.5" }
 
 [features]
 web_sys_0_3 = ["dep:web_sys_0_3"]

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.5](https://github.com/aschey/terminput/compare/terminput-v0.5.4..terminput-v0.5.5) - 2025-08-19
+
+### Miscellaneous Tasks
+
+- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
+
 ## [0.5.4](https://github.com/aschey/terminput/compare/terminput-v0.5.3..terminput-v0.5.4) - 2025-08-15
 
 ### Features

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.4"
+version = "0.5.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.5.4 -> 0.5.5 (✓ API compatible changes)
* `terminput-crossterm`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `terminput-egui`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `terminput-termion`: 0.3.0 -> 0.3.1 (✓ API compatible changes)
* `terminput-termwiz`: 0.4.0 -> 0.4.1 (✓ API compatible changes)
* `terminput-web-sys`: 0.2.0 -> 0.2.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.5](https://github.com/aschey/terminput/compare/terminput-v0.5.4..terminput-v0.5.5) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.4.1](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.0..terminput-crossterm-v0.4.1) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.4.1](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.0..terminput-egui-v0.4.1) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.1](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.0..terminput-termion-v0.3.1) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.4.1](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.0..terminput-termwiz-v0.4.1) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>

## `terminput-web-sys`

<blockquote>

## [0.2.1](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.0..terminput-web-sys-v0.2.1) - 2025-08-19

### Miscellaneous Tasks

- Include license in build ([#59](https://github.com/aschey/terminput/issues/59)) - ([eb9fadc](https://github.com/aschey/terminput/commit/eb9fadc58bb9d8f1ddef2e1d44738257e9c519f0))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).