### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.2..terminput-crossterm-v0.4.3) - 2025-08-31
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+
+### Refactor
+
+- Map key event state explicitly ([#67](https://github.com/aschey/terminput/issues/67)) - ([5acc427](https://github.com/aschey/terminput/commit/5acc4272d525af83e195c3ced396eeb0ee35c24f))
+
 ## [0.4.2](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.1..terminput-crossterm-v0.4.2) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ default-features = false
 features = ["events", "bracketed-paste", "windows"]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 crossterm_0_28 = ["dep:crossterm_0_28"]

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.2..terminput-egui-v0.4.3) - 2025-08-31
+
+### Features
+
+- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+
 ## [0.4.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.1..terminput-egui-v0.4.2) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui_0_32 = { package = "egui", version = "0.32", default-features = false, optional = true }
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 egui_0_32 = ["dep:egui_0_32"]

--- a/crates/terminput-termina/CHANGELOG.md
+++ b/crates/terminput-termina/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-08-31
+
+### Features
+
+- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+

--- a/crates/terminput-termina/Cargo.toml
+++ b/crates/terminput-termina/Cargo.toml
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termina_0_1 = { package = "termina", version = "0.1", optional = true }
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 termina_0_1 = ["dep:termina_0_1"]

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.2..terminput-termion-v0.3.3) - 2025-08-31
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+
 ## [0.3.2](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.1..terminput-termion-v0.3.2) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.3.2"
+version = "0.3.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion_4 = { package = "termion", version = "4", optional = true }
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 termion_4 = ["dep:termion_4"]

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.3](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.2..terminput-termwiz-v0.4.3) - 2025-08-31
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+
 ## [0.4.2](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.1..terminput-termwiz-v0.4.2) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.4.2"
+version = "0.4.3"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ readme = "./README.md"
 [dependencies]
 termwiz_0_23 = { package = "termwiz", version = "0.23", optional = true }
 termwiz_0_22 = { package = "termwiz", version = "0.22", optional = true }
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 termwiz_0_23 = ["dep:termwiz_0_23"]

--- a/crates/terminput-web-sys/CHANGELOG.md
+++ b/crates/terminput-web-sys/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.3](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.2..terminput-web-sys-v0.2.3) - 2025-08-31
+
+### Miscellaneous Tasks
+
+- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
+
 ## [0.2.2](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.1..terminput-web-sys-v0.2.2) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput-web-sys/Cargo.toml
+++ b/crates/terminput-web-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-web-sys"
-version = "0.2.2"
+version = "0.2.3"
 description = "web-sys adapter for terminput"
 edition.workspace = true
 rust-version.workspace = true
@@ -30,7 +30,7 @@ features = [
 ]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.6" }
+terminput = { path = "../terminput", version = "0.5.7" }
 
 [features]
 web_sys_0_3 = ["dep:web_sys_0_3"]

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.7](https://github.com/aschey/terminput/compare/terminput-v0.5.6..terminput-v0.5.7) - 2025-08-31
+
+### Features
+
+- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))
+
 ## [0.5.6](https://github.com/aschey/terminput/compare/terminput-v0.5.5..terminput-v0.5.6) - 2025-08-25
 
 ### Miscellaneous Tasks

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.6"
+version = "0.5.7"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.5.6 -> 0.5.7 (✓ API compatible changes)
* `terminput-crossterm`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `terminput-egui`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `terminput-termina`: 0.1.0
* `terminput-termion`: 0.3.2 -> 0.3.3 (✓ API compatible changes)
* `terminput-termwiz`: 0.4.2 -> 0.4.3 (✓ API compatible changes)
* `terminput-web-sys`: 0.2.2 -> 0.2.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.7](https://github.com/aschey/terminput/compare/terminput-v0.5.6..terminput-v0.5.7) - 2025-08-31

### Features

- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.4.3](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.2..terminput-crossterm-v0.4.3) - 2025-08-31

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))

### Refactor

- Map key event state explicitly ([#67](https://github.com/aschey/terminput/issues/67)) - ([5acc427](https://github.com/aschey/terminput/commit/5acc4272d525af83e195c3ced396eeb0ee35c24f))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.4.3](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.2..terminput-egui-v0.4.3) - 2025-08-31

### Features

- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
</blockquote>

## `terminput-termina`

<blockquote>

## [0.1.0] - 2025-08-31

### Features

- Termina adapter ([#64](https://github.com/aschey/terminput/issues/64)) - ([5ca8d69](https://github.com/aschey/terminput/commit/5ca8d69ededfa25bef8184dd4f9f11e5fc6fd248))

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.3](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.2..terminput-termion-v0.3.3) - 2025-08-31

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.4.3](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.2..terminput-termwiz-v0.4.3) - 2025-08-31

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
</blockquote>

## `terminput-web-sys`

<blockquote>

## [0.2.3](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.2..terminput-web-sys-v0.2.3) - 2025-08-31

### Miscellaneous Tasks

- Remove dependency status ([#66](https://github.com/aschey/terminput/issues/66)) - ([0326a5a](https://github.com/aschey/terminput/commit/0326a5a0c0249a07ec226bfcbb007c00b43db489))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).