### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.5](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.4..terminput-crossterm-v0.4.5) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.4.4](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.3..terminput-crossterm-v0.4.4) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ default-features = false
 features = ["events", "bracketed-paste", "windows"]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 crossterm_0_28 = ["dep:crossterm_0_28"]

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.5](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.4..terminput-egui-v0.4.5) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.4.4](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.3..terminput-egui-v0.4.4) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 egui_0_32 = { package = "egui", version = "0.32", default-features = false, optional = true }
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 egui_0_32 = ["dep:egui_0_32"]

--- a/crates/terminput-termina/CHANGELOG.md
+++ b/crates/terminput-termina/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.2](https://github.com/aschey/terminput/compare/terminput-termina-v0.1.1..terminput-termina-v0.1.2) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.1.1](https://github.com/aschey/terminput/compare/terminput-termina-v0.1.0..terminput-termina-v0.1.1) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termina/Cargo.toml
+++ b/crates/terminput-termina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termina"
-version = "0.1.1"
+version = "0.1.2"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termina_0_1 = { package = "termina", version = "0.1", optional = true }
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 termina_0_1 = ["dep:termina_0_1"]

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.5](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.4..terminput-termion-v0.3.5) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.3.4](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.3..terminput-termion-v0.3.4) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.3.4"
+version = "0.3.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion_4 = { package = "termion", version = "4", optional = true }
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 termion_4 = ["dep:termion_4"]

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.5](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.4..terminput-termwiz-v0.4.5) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.4.4](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.3..terminput-termwiz-v0.4.4) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.4.4"
+version = "0.4.5"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ readme = "./README.md"
 [dependencies]
 termwiz_0_23 = { package = "termwiz", version = "0.23", optional = true }
 termwiz_0_22 = { package = "termwiz", version = "0.22", optional = true }
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 termwiz_0_23 = ["dep:termwiz_0_23"]

--- a/crates/terminput-web-sys/CHANGELOG.md
+++ b/crates/terminput-web-sys/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.5](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.4..terminput-web-sys-v0.2.5) - 2025-09-03
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
 ## [0.2.4](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.3..terminput-web-sys-v0.2.4) - 2025-08-31
 
 ### Miscellaneous Tasks

--- a/crates/terminput-web-sys/Cargo.toml
+++ b/crates/terminput-web-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-web-sys"
-version = "0.2.4"
+version = "0.2.5"
 description = "web-sys adapter for terminput"
 edition.workspace = true
 rust-version.workspace = true
@@ -30,7 +30,7 @@ features = [
 ]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.8" }
+terminput = { path = "../terminput", version = "0.5.9" }
 
 [features]
 web_sys_0_3 = ["dep:web_sys_0_3"]

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.9](https://github.com/aschey/terminput/compare/terminput-v0.5.8..terminput-v0.5.9) - 2025-09-03
+
+### Bug Fixes
+
+- Prevent subtraction with overlow on invalid mouse coordinates ([#70](https://github.com/aschey/terminput/issues/70)) - ([75ab7be](https://github.com/aschey/terminput/commit/75ab7be296e5e78f5125349ddef85aa9b2a7c48f))
+
 ## [0.5.8](https://github.com/aschey/terminput/compare/terminput-v0.5.7..terminput-v0.5.8) - 2025-08-31
 
 ### Features

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 
 ### Bug Fixes
 
-- Prevent subtraction with overlow on invalid mouse coordinates ([#70](https://github.com/aschey/terminput/issues/70)) - ([75ab7be](https://github.com/aschey/terminput/commit/75ab7be296e5e78f5125349ddef85aa9b2a7c48f))
+- Prevent subtraction with overflow on invalid mouse coordinates ([#70](https://github.com/aschey/terminput/issues/70)) - ([75ab7be](https://github.com/aschey/terminput/commit/75ab7be296e5e78f5125349ddef85aa9b2a7c48f))
 
 ## [0.5.8](https://github.com/aschey/terminput/compare/terminput-v0.5.7..terminput-v0.5.8) - 2025-08-31
 

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.8"
+version = "0.5.9"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true

--- a/crates/terminput/src/parser/mod.rs
+++ b/crates/terminput/src/parser/mod.rs
@@ -668,8 +668,8 @@ pub(crate) fn parse_csi_normal_mouse(buffer: &[u8]) -> io::Result<Option<Event>>
     // See http://www.xfree86.org/current/ctlseqs.html#Mouse%20Tracking
     // The upper left character position on the terminal is denoted as 1,1.
     // Subtract 1 to keep it synced with cursor
-    let cx = u16::from(buffer[4].saturating_sub(32)) - 1;
-    let cy = u16::from(buffer[5].saturating_sub(32)) - 1;
+    let cx = u16::from(buffer[4].saturating_sub(33));
+    let cy = u16::from(buffer[5].saturating_sub(33));
 
     Ok(Some(Event::Mouse(MouseEvent {
         kind,

--- a/crates/terminput/tests/parse_test.rs
+++ b/crates/terminput/tests/parse_test.rs
@@ -1585,6 +1585,16 @@ fn test_parse_from_subsequent_calls() {
             modifiers: KeyModifiers::CTRL,
         }))
     );
+    // mouse with invalid coordinates (should return 0 and not panic)
+    assert_eq!(
+        Event::parse_from(b"\x1B[M0\x00\x00").unwrap(),
+        Some(Event::Mouse(MouseEvent {
+            kind: MouseEventKind::Down(MouseButton::Left),
+            column: 0,
+            row: 0,
+            modifiers: KeyModifiers::CTRL,
+        }))
+    );
 
     // parse_csi_sgr_mouse
     assert_eq!(


### PR DESCRIPTION


## 🤖 New release

* `terminput`: 0.5.8 -> 0.5.9 (✓ API compatible changes)
* `terminput-crossterm`: 0.4.4 -> 0.4.5
* `terminput-egui`: 0.4.4 -> 0.4.5
* `terminput-termina`: 0.1.1 -> 0.1.2
* `terminput-termion`: 0.3.4 -> 0.3.5
* `terminput-termwiz`: 0.4.4 -> 0.4.5
* `terminput-web-sys`: 0.2.4 -> 0.2.5

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.9](https://github.com/aschey/terminput/compare/terminput-v0.5.8..terminput-v0.5.9) - 2025-09-03

### Bug Fixes

- Prevent subtraction with overflow on invalid mouse coordinates ([#70](https://github.com/aschey/terminput/issues/70)) - ([75ab7be](https://github.com/aschey/terminput/commit/75ab7be296e5e78f5125349ddef85aa9b2a7c48f))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.4.5](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.4..terminput-crossterm-v0.4.5) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.4.5](https://github.com/aschey/terminput/compare/terminput-egui-v0.4.4..terminput-egui-v0.4.5) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termina`

<blockquote>

## [0.1.2](https://github.com/aschey/terminput/compare/terminput-termina-v0.1.1..terminput-termina-v0.1.2) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.5](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.4..terminput-termion-v0.3.5) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.4.5](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.4..terminput-termwiz-v0.4.5) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-web-sys`

<blockquote>

## [0.2.5](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.4..terminput-web-sys-v0.2.5) - 2025-09-03

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).