### PR TITLE
chore: release

### DIFF
--- a/crates/terminput-crossterm/CHANGELOG.md
+++ b/crates/terminput-crossterm/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.10](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.9..terminput-crossterm-v0.4.10) - 2026-03-29
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
+
 ## [0.4.9](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.8..terminput-crossterm-v0.4.9) - 2026-03-21
 
 ### Miscellaneous Tasks

--- a/crates/terminput-crossterm/Cargo.toml
+++ b/crates/terminput-crossterm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-crossterm"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -28,7 +28,7 @@ default-features = false
 features = ["events", "bracketed-paste", "windows"]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 crossterm_0_28 = ["dep:crossterm_0_28"]

--- a/crates/terminput-egui/CHANGELOG.md
+++ b/crates/terminput-egui/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0](https://github.com/aschey/terminput/compare/terminput-egui-v0.5.2..terminput-egui-v0.6.0) - 2026-03-29
+
+### Dependencies
+
+- *(deps)* Update egui to 0.34 ([#97](https://github.com/aschey/terminput/issues/97)) - ([1328a24](https://github.com/aschey/terminput/commit/1328a243a75262c75bf459f1ac02fa913c560c54))
+
+
 ## [0.5.2](https://github.com/aschey/terminput/compare/terminput-egui-v0.5.1..terminput-egui-v0.5.2) - 2026-03-21
 
 ### Miscellaneous Tasks

--- a/crates/terminput-egui/Cargo.toml
+++ b/crates/terminput-egui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-egui"
-version = "0.5.2"
+version = "0.6.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -17,7 +17,7 @@ readme = "./README.md"
 egui_0_32 = { package = "egui", version = "0.32", default-features = false, optional = true }
 egui_0_33 = { package = "egui", version = "0.33", default-features = false, optional = true }
 egui_0_34 = { package = "egui", version = "0.34", default-features = false, optional = true }
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 egui_0_32 = ["dep:egui_0_32"]

--- a/crates/terminput-termina/CHANGELOG.md
+++ b/crates/terminput-termina/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.0](https://github.com/aschey/terminput/compare/terminput-termina-v0.2.0..terminput-termina-v0.3.0) - 2026-03-29
+
+### Dependencies
+
+- *(deps)* Update termina to 0.3 ([#95](https://github.com/aschey/terminput/issues/95)) - ([ee9e841](https://github.com/aschey/terminput/commit/ee9e8418bebc92feacbb4294592c7bbb68f06f17))
+
+
 ## [0.2.0](https://github.com/aschey/terminput/compare/terminput-termina-v0.1.5..terminput-termina-v0.2.0) - 2026-03-21
 
 ### Dependencies

--- a/crates/terminput-termina/Cargo.toml
+++ b/crates/terminput-termina/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termina"
-version = "0.2.0"
+version = "0.3.0"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [dependencies]
 termina_0_3 = { package = "termina", version = "0.3", optional = true }
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 termina_0_3 = ["dep:termina_0_3"]

--- a/crates/terminput-termion/CHANGELOG.md
+++ b/crates/terminput-termion/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.3.10](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.9..terminput-termion-v0.3.10) - 2026-03-29
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
+
 ## [0.3.9](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.8..terminput-termion-v0.3.9) - 2026-03-21
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termion/Cargo.toml
+++ b/crates/terminput-termion/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termion"
-version = "0.3.9"
+version = "0.3.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -15,7 +15,7 @@ readme = "./README.md"
 
 [target.'cfg(not(windows))'.dependencies]
 termion_4 = { package = "termion", version = "4", optional = true }
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 termion_4 = ["dep:termion_4"]

--- a/crates/terminput-termwiz/CHANGELOG.md
+++ b/crates/terminput-termwiz/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.10](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.9..terminput-termwiz-v0.4.10) - 2026-03-29
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
+
 ## [0.4.9](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.8..terminput-termwiz-v0.4.9) - 2026-03-21
 
 ### Miscellaneous Tasks

--- a/crates/terminput-termwiz/Cargo.toml
+++ b/crates/terminput-termwiz/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-termwiz"
-version = "0.4.9"
+version = "0.4.10"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true
@@ -16,7 +16,7 @@ readme = "./README.md"
 [dependencies]
 termwiz_0_23 = { package = "termwiz", version = "0.23", optional = true }
 termwiz_0_22 = { package = "termwiz", version = "0.22", optional = true }
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 termwiz_0_23 = ["dep:termwiz_0_23"]

--- a/crates/terminput-web-sys/CHANGELOG.md
+++ b/crates/terminput-web-sys/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.2.10](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.9..terminput-web-sys-v0.2.10) - 2026-03-29
+
+### Miscellaneous Tasks
+
+- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
+
+
 ## [0.2.9](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.8..terminput-web-sys-v0.2.9) - 2026-03-21
 
 ### Miscellaneous Tasks

--- a/crates/terminput-web-sys/Cargo.toml
+++ b/crates/terminput-web-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput-web-sys"
-version = "0.2.9"
+version = "0.2.10"
 description = "web-sys adapter for terminput"
 edition.workspace = true
 rust-version.workspace = true
@@ -30,7 +30,7 @@ features = [
 ]
 
 [dependencies]
-terminput = { path = "../terminput", version = "0.5.13" }
+terminput = { path = "../terminput", version = "0.5.14" }
 
 [features]
 web_sys_0_3 = ["dep:web_sys_0_3"]

--- a/crates/terminput/CHANGELOG.md
+++ b/crates/terminput/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.14](https://github.com/aschey/terminput/compare/terminput-v0.5.13..terminput-v0.5.14) - 2026-03-29
+
+### Dependencies
+
+- *(deps)* Update termina to 0.3 ([#95](https://github.com/aschey/terminput/issues/95)) - ([ee9e841](https://github.com/aschey/terminput/commit/ee9e8418bebc92feacbb4294592c7bbb68f06f17))
+- *(deps)* Update egui to 0.34 ([#97](https://github.com/aschey/terminput/issues/97)) - ([1328a24](https://github.com/aschey/terminput/commit/1328a243a75262c75bf459f1ac02fa913c560c54))
+
+
 ## [0.5.13](https://github.com/aschey/terminput/compare/terminput-v0.5.12..terminput-v0.5.13) - 2026-03-21
 
 ### Dependencies

--- a/crates/terminput/Cargo.toml
+++ b/crates/terminput/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "terminput"
-version = "0.5.13"
+version = "0.5.14"
 edition.workspace = true
 rust-version.workspace = true
 authors.workspace = true


### PR DESCRIPTION



## 🤖 New release

* `terminput`: 0.5.13 -> 0.5.14 (✓ API compatible changes)
* `terminput-egui`: 0.5.2 -> 0.6.0 (⚠ API breaking changes)
* `terminput-termina`: 0.2.0 -> 0.3.0 (⚠ API breaking changes)
* `terminput-crossterm`: 0.4.9 -> 0.4.10
* `terminput-termion`: 0.3.9 -> 0.3.10
* `terminput-termwiz`: 0.4.9 -> 0.4.10
* `terminput-web-sys`: 0.2.9 -> 0.2.10

### ⚠ `terminput-egui` breaking changes

```text
--- failure feature_not_enabled_by_default: package feature is not enabled by default ---

Description:
A feature is no longer enabled by default for this package. This will break downstream crates which rely on the package's default features and require the functionality of this feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove-another
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_not_enabled_by_default.ron

Failed in:
  feature egui_0_33 in the package's Cargo.toml
```

### ⚠ `terminput-termina` breaking changes

```text
--- failure feature_missing: package feature removed or renamed ---

Description:
A feature has been removed from this package's Cargo.toml. This will break downstream crates which enable that feature.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#cargo-feature-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/feature_missing.ron

Failed in:
  feature termina_0_2 in the package's Cargo.toml
```

<details><summary><i><b>Changelog</b></i></summary><p>

## `terminput`

<blockquote>

## [0.5.14](https://github.com/aschey/terminput/compare/terminput-v0.5.13..terminput-v0.5.14) - 2026-03-29

### Dependencies

- *(deps)* Update termina to 0.3 ([#95](https://github.com/aschey/terminput/issues/95)) - ([ee9e841](https://github.com/aschey/terminput/commit/ee9e8418bebc92feacbb4294592c7bbb68f06f17))
- *(deps)* Update egui to 0.34 ([#97](https://github.com/aschey/terminput/issues/97)) - ([1328a24](https://github.com/aschey/terminput/commit/1328a243a75262c75bf459f1ac02fa913c560c54))
</blockquote>

## `terminput-egui`

<blockquote>

## [0.6.0](https://github.com/aschey/terminput/compare/terminput-egui-v0.5.2..terminput-egui-v0.6.0) - 2026-03-29

### Dependencies

- *(deps)* Update egui to 0.34 ([#97](https://github.com/aschey/terminput/issues/97)) - ([1328a24](https://github.com/aschey/terminput/commit/1328a243a75262c75bf459f1ac02fa913c560c54))
</blockquote>

## `terminput-termina`

<blockquote>

## [0.3.0](https://github.com/aschey/terminput/compare/terminput-termina-v0.2.0..terminput-termina-v0.3.0) - 2026-03-29

### Dependencies

- *(deps)* Update termina to 0.3 ([#95](https://github.com/aschey/terminput/issues/95)) - ([ee9e841](https://github.com/aschey/terminput/commit/ee9e8418bebc92feacbb4294592c7bbb68f06f17))
</blockquote>

## `terminput-crossterm`

<blockquote>

## [0.4.10](https://github.com/aschey/terminput/compare/terminput-crossterm-v0.4.9..terminput-crossterm-v0.4.10) - 2026-03-29

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termion`

<blockquote>

## [0.3.10](https://github.com/aschey/terminput/compare/terminput-termion-v0.3.9..terminput-termion-v0.3.10) - 2026-03-29

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-termwiz`

<blockquote>

## [0.4.10](https://github.com/aschey/terminput/compare/terminput-termwiz-v0.4.9..terminput-termwiz-v0.4.10) - 2026-03-29

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>

## `terminput-web-sys`

<blockquote>

## [0.2.10](https://github.com/aschey/terminput/compare/terminput-web-sys-v0.2.9..terminput-web-sys-v0.2.10) - 2026-03-29

### Miscellaneous Tasks

- Updated the following local packages: terminput - ([0000000](https://github.com/aschey/terminput/commit/0000000))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).